### PR TITLE
Change the value of may_create_new_version instead of legit boolean t…

### DIFF
--- a/lib/Api/CourseApi.php
+++ b/lib/Api/CourseApi.php
@@ -972,7 +972,7 @@ class CourseApi
         }
         // query params
         if ($may_create_new_version !== null) {
-            $queryParams['mayCreateNewVersion'] = ObjectSerializer::toQueryValue($may_create_new_version);
+            $queryParams['mayCreateNewVersion'] = $may_create_new_version ? "true" : "false";
         }
         // header params
         if ($engine_tenant_name !== null) {


### PR DESCRIPTION
…o be a string, because the build_query method is converting it to an int value, and the endpoint is expecting the string value instead of the int value